### PR TITLE
Fix date string handling and update test case formatting

### DIFF
--- a/kirun-java/src/main/java/com/fincity/nocode/kirun/engine/function/system/date/FromDateString.java
+++ b/kirun-java/src/main/java/com/fincity/nocode/kirun/engine/function/system/date/FromDateString.java
@@ -43,9 +43,9 @@ public class FromDateString extends AbstractDateFunction {
         ZonedDateTime currentTime = ZonedDateTime.now();
 
         TemporalAccessor accessor = new DateTimeFormatterBuilder().appendPattern(DateUtil.toDateTimeFormat(format))
-                .parseDefaulting(ChronoField.YEAR, currentTime.get(ChronoField.YEAR))
-                .parseDefaulting(ChronoField.MONTH_OF_YEAR, currentTime.get(ChronoField.MONTH_OF_YEAR))
-                .parseDefaulting(ChronoField.DAY_OF_MONTH, currentTime.get(ChronoField.DAY_OF_MONTH))
+                .parseDefaulting(ChronoField.YEAR_OF_ERA, currentTime.getYear())
+                .parseDefaulting(ChronoField.MONTH_OF_YEAR, currentTime.getMonthValue())
+                .parseDefaulting(ChronoField.DAY_OF_MONTH, currentTime.getDayOfMonth())
                 .parseDefaulting(ChronoField.HOUR_OF_DAY, 0)
                 .parseDefaulting(ChronoField.MINUTE_OF_HOUR, 0)
                 .parseDefaulting(ChronoField.SECOND_OF_MINUTE, 0)

--- a/kirun-java/src/test/java/com/fincity/nocode/kirun/engine/function/system/date/FromDateStringTest.java
+++ b/kirun-java/src/test/java/com/fincity/nocode/kirun/engine/function/system/date/FromDateStringTest.java
@@ -29,9 +29,9 @@ class FromDateStringTest {
                                 new JsonPrimitive("yyyy-dd")));
 
         StepVerifier.create(fromDateString.execute(parameters)
-                .map(functionOutput -> functionOutput.allResults().get(0).getResult()
+                .map(functionOutput -> functionOutput.allResults().getFirst().getResult()
                         .get(FromDateString.EVENT_TIMESTAMP_NAME).getAsString()))
-                .expectNext("2024-" + LocalDate.now().getMonthValue() + "-03T00:00:00.000Z")
-                .verifyComplete();
+            .expectNext("2024-" + String.format("%02d", LocalDate.now().getMonthValue()) + "-03T00:00:00.000Z")
+            .verifyComplete();
     }
 }


### PR DESCRIPTION
Updated the test case to use zero-padded month values for consistency. Modified `FromDateString` to default to `ChronoField.YEAR_OF_ERA` instead of `YEAR` for improved date parsing accuracy.