### PR TITLE
Bump versions to 2.15.1 (JS) and 3.13.1 (Java), extend `SchemaDetails…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
+.idea/**
 .idea

--- a/kirun-java/pom.xml
+++ b/kirun-java/pom.xml
@@ -11,7 +11,7 @@
     </parent>
     <groupId>com.fincity.nocode</groupId>
     <artifactId>kirun-java</artifactId>
-    <version>3.13.0</version>
+    <version>3.13.1</version>
     <name>kirun-java</name>
     <description>Interpreter to execute the visual code based on KIRun JSON on the Java layer</description>
     <properties>

--- a/kirun-java/src/main/java/com/fincity/nocode/kirun/engine/json/schema/Schema.java
+++ b/kirun-java/src/main/java/com/fincity/nocode/kirun/engine/json/schema/Schema.java
@@ -119,7 +119,9 @@ public class Schema implements Serializable {
 
 					entry("permission", ofString("permission")),
 
-					entry("details", ofObject("details"))))
+					entry("details", ofObject("details")),
+					entry("viewDetails", ofObject("viewDetails"))
+					))
 			.setRequired(List.of());
 
 	public static Schema ofString(String id) {
@@ -246,7 +248,8 @@ public class Schema implements Serializable {
 	private Map<String, Schema> $defs; // NOSONAR - needed as per json schema
 	private String permission;
 
-	private SchemaDetails details; // NOSONAR - needed as per json schema
+	private SchemaDetails details;
+	private SchemaDetails viewDetails;
 
 	public String getTitle() {
 
@@ -364,5 +367,6 @@ public class Schema implements Serializable {
 		this.permission = schema.permission;
 
 		this.details = schema.details == null ? null : new SchemaDetails(schema.details);
+		this.viewDetails = schema.viewDetails == null ? null : new SchemaDetails(schema.viewDetails);
 	}
 }

--- a/kirun-java/src/main/java/com/fincity/nocode/kirun/engine/json/schema/SchemaDetails.java
+++ b/kirun-java/src/main/java/com/fincity/nocode/kirun/engine/json/schema/SchemaDetails.java
@@ -27,12 +27,16 @@ public class SchemaDetails {
     private Map<String, String> validationMessages;
     private Map<String, Object> properties;
     private Map<String, Object> styleProperties;
+    private Integer order;
+    private String label;
 
     public SchemaDetails(SchemaDetails schemaDetails) {
         this.preferredComponent = schemaDetails.preferredComponent;
         this.validationMessages = schemaDetails.validationMessages;
         this.properties = schemaDetails.properties;
         this.styleProperties = schemaDetails.styleProperties;
+        this.order = schemaDetails.order;
+        this.label = schemaDetails.label;
     }
 
     public String getValidationMessage(String validationType, String defaultMessage) {

--- a/kirun-js/package.json
+++ b/kirun-js/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@fincity/kirun-js",
-    "version": "2.15.0",
+    "version": "2.15.1",
     "description": "Javascript Runtime for Kinetic Instructions",
     "source": "src/index.ts",
     "main": "dist/index.js",

--- a/kirun-js/src/engine/json/schema/Schema.ts
+++ b/kirun-js/src/engine/json/schema/Schema.ts
@@ -67,6 +67,8 @@ export class SchemaDetails {
     private validationMessages?: Map<string, string>;
     private properties?: Map<String, any>;
     private styleProperties?: Map<String, any>;
+    private order?: number;
+    private label?: string;
 
     constructor(sd: SchemaDetails | undefined = undefined) {
         if (!sd) return;
@@ -79,6 +81,8 @@ export class SchemaDetails {
             this.properties = new Map<String, any>(Array.from(sd.properties.entries()));
         if (sd.styleProperties)
             this.styleProperties = new Map<String, any>(Array.from(sd.styleProperties.entries()));
+        this.order = sd.order;
+        this.label = sd.label;
     }
 
     public getPreferredComponent(): string | undefined {
@@ -121,11 +125,31 @@ export class SchemaDetails {
         return this.styleProperties;
     }
 
+    public getOrder(): number | undefined {
+        return this.order;
+    }
+
+    public setOrder(order: number | undefined): SchemaDetails {
+        this.order = order;
+        return this;
+    }
+
+    public getLabel(): string | undefined {
+        return this.label;
+    }
+
+    public setLabel(label: string | undefined): SchemaDetails {
+        this.label = label;
+        return this;
+    }
+
     public static from(detail: {
         preferredComponent: string | undefined;
         validationMessages: { [key : string] : string } | undefined;
         properties: { [key : string] : any } | undefined;
         styleProperties: { [key : string] : any } | undefined;
+        order: number | undefined;
+        label: string | undefined;
     }): SchemaDetails | undefined {
         if (!detail) return undefined;
 
@@ -135,7 +159,9 @@ export class SchemaDetails {
             .setProperties(detail.properties ?
                 new Map<string, any>(Object.entries(detail.properties)) : undefined)
             .setStyleProperties(detail.styleProperties ?
-                new Map<string, any>(Object.entries(detail.styleProperties)) : undefined);
+                new Map<string, any>(Object.entries(detail.styleProperties)) : undefined)
+            .setOrder(detail.order)
+            .setLabel(detail.label);
     }
 }
 
@@ -283,6 +309,7 @@ export class Schema {
 
                 ['permission', Schema.ofString('permission')],
                 ['details', Schema.ofObject('details')],
+                ['viewDetails', Schema.ofObject('viewDetails')],
             ]),
         )
         .setRequired([]);
@@ -465,6 +492,7 @@ export class Schema {
         schema.permission = obj.permission;
 
         schema.details = obj.details ? SchemaDetails.from(obj.details) : undefined;
+        schema.viewDetails = obj.viewDetails ? SchemaDetails.from(obj.viewDetails) : undefined;
 
         return schema;
     }
@@ -525,6 +553,7 @@ export class Schema {
     private permission?: string;
 
     private details?: SchemaDetails;
+    private viewDetails?: SchemaDetails;
 
     public constructor(schema?: Schema) {
         if (!schema) return;
@@ -611,6 +640,7 @@ export class Schema {
 
         this.permission = schema.permission;
         this.details = schema.details;
+        this.viewDetails = schema.viewDetails;
     }
 
     public getTitle(): string | undefined {
@@ -927,6 +957,15 @@ export class Schema {
 
     public setDetails(details: SchemaDetails): Schema {
         this.details = details;
+        return this;
+    }
+
+    public getViewDetails(): SchemaDetails | undefined {
+        return this.viewDetails;
+    }
+
+    public setViewDetails(viewDetails: SchemaDetails): Schema {
+        this.viewDetails = viewDetails;
         return this;
     }
 }


### PR DESCRIPTION
…` with `order` and `label` properties, and introduce `viewDetails` management in `Schema`.